### PR TITLE
Alteração para Mock

### DIFF
--- a/bank_statement.go
+++ b/bank_statement.go
@@ -2,14 +2,12 @@ package bankly
 
 import (
 	"encoding/json"
+	"github.com/contbank/grok"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
-	"time"
-
-	"github.com/contbank/grok"
 )
 
 //BankStatement ...
@@ -20,13 +18,11 @@ type BankStatement struct {
 }
 
 //NewBankStatement ...
-func NewBankStatement(session Session) *BankStatement {
+func NewBankStatement(httpClient *http.Client, session Session) *BankStatement {
 	return &BankStatement{
-		session: session,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		authentication: NewAuthentication(session),
+		session : session,
+		httpClient : httpClient,
+		authentication : NewAuthentication(session),
 	}
 }
 

--- a/bank_statement_test.go
+++ b/bank_statement_test.go
@@ -1,6 +1,7 @@
 package bankly_test
 
 import (
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -33,9 +34,13 @@ func (s *BankStatementTestSuite) SetupTest() {
 
 	s.assert.NoError(err)
 
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
 	s.session = session
-	s.bank = bankly.NewBankStatement(*s.session)
-	s.boletos = bankly.NewBoletos(*s.session)
+	s.bank = bankly.NewBankStatement(httpClient, *s.session)
+	s.boletos = bankly.NewBoletos(httpClient, *s.session)
 }
 
 func (s *BankStatementTestSuite) TestFilterBankStatements() {

--- a/boletos.go
+++ b/boletos.go
@@ -21,13 +21,11 @@ type Boletos struct {
 }
 
 //NewBoletos ...
-func NewBoletos(session Session) *Boletos {
-	return &Boletos{
-		session: session,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		authentication: NewAuthentication(session),
+func NewBoletos(httpClient *http.Client, session Session) *Boletos {
+	return &Boletos {
+		session : session,
+		httpClient : httpClient,
+		authentication : NewAuthentication(session),
 	}
 }
 
@@ -130,7 +128,7 @@ func (b *Boletos) FindBoleto(model *FindBoletoRequest) (*BoletoDetailedResponse,
 	u.Path = path.Join(u.Path, model.Account.Number)
 	u.Path = path.Join(u.Path, model.AuthenticationCode)
 	endpoint := u.String()
-
+	
 	req, err := http.NewRequest("GET", endpoint, nil)
 
 	if err != nil {

--- a/boletos_test.go
+++ b/boletos_test.go
@@ -1,8 +1,10 @@
 package bankly_test
 
 import (
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	bankly "github.com/contbank/bankly-sdk"
 	"github.com/stretchr/testify/assert"
@@ -31,9 +33,13 @@ func (s *BoletosTestSuite) SetupTest() {
 
 	s.assert.NoError(err)
 
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
 	s.session = session
-	s.boletos = bankly.NewBoletos(*s.session)
-	s.customers = bankly.NewCustomers(*s.session)
+	s.boletos = bankly.NewBoletos(httpClient, *s.session)
+	s.customers = bankly.NewCustomers(httpClient, *s.session)
 }
 
 /*

--- a/business.go
+++ b/business.go
@@ -3,14 +3,12 @@ package bankly
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/contbank/grok"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
-	"time"
-
-	"github.com/contbank/grok"
-	"github.com/sirupsen/logrus"
 )
 
 //Business ...
@@ -21,13 +19,11 @@ type Business struct {
 }
 
 //NewBusiness ...
-func NewBusiness(session Session) *Business {
+func NewBusiness(httpClient *http.Client, session Session) *Business {
 	return &Business{
-		session: session,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		authentication: NewAuthentication(session),
+		session : session,
+		httpClient : httpClient,
+		authentication : NewAuthentication(session),
 	}
 }
 

--- a/business_test.go
+++ b/business_test.go
@@ -1,6 +1,7 @@
 package bankly_test
 
 import (
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -32,8 +33,12 @@ func (s *BusinessTestSuite) SetupTest() {
 
 	s.assert.NoError(err)
 
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
 	s.session = session
-	s.business = bankly.NewBusiness(*s.session)
+	s.business = bankly.NewBusiness(httpClient, *s.session)
 }
 
 func (s *BusinessTestSuite) TestCreateBusiness_TypeEI_SizeME() {

--- a/customers.go
+++ b/customers.go
@@ -3,14 +3,12 @@ package bankly
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/contbank/grok"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
-	"time"
-
-	"github.com/contbank/grok"
-	"github.com/sirupsen/logrus"
 )
 
 //Customers ...
@@ -21,13 +19,11 @@ type Customers struct {
 }
 
 //NewCustomers ...
-func NewCustomers(session Session) *Customers {
+func NewCustomers(httpClient *http.Client, session Session) *Customers {
 	return &Customers{
-		session: session,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		authentication: NewAuthentication(session),
+		session : session,
+		httpClient : httpClient,
+		authentication : NewAuthentication(session),
 	}
 }
 

--- a/customers_test.go
+++ b/customers_test.go
@@ -2,6 +2,7 @@ package bankly_test
 
 import (
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -34,8 +35,12 @@ func (s *CustomersTestSuite) SetupTest() {
 
 	s.assert.NoError(err)
 
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
 	s.session = session
-	s.customers = bankly.NewCustomers(*s.session)
+	s.customers = bankly.NewCustomers(httpClient, *s.session)
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/payment.go
+++ b/payment.go
@@ -3,14 +3,12 @@ package bankly
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/contbank/grok"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
-	"time"
-
-	"github.com/contbank/grok"
 )
 
 //Payment ...
@@ -21,12 +19,10 @@ type Payment struct {
 }
 
 //NewPayment ...
-func NewPayment(session Session) *Payment {
+func NewPayment(httpClient *http.Client, session Session) *Payment {
 	return &Payment{
 		session: session,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		httpClient: httpClient,
 		authentication: NewAuthentication(session),
 	}
 }

--- a/payment_test.go
+++ b/payment_test.go
@@ -1,8 +1,10 @@
 package bankly_test
 
 import (
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/contbank/bankly-sdk"
 
@@ -31,8 +33,12 @@ func (s *PaymentTestSuite) SetupTest() {
 
 	s.assert.NoError(err)
 
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
 	s.session = session
-	s.payment = bankly.NewPayment(*s.session)
+	s.payment = bankly.NewPayment(httpClient, *s.session)
 }
 
 // func (s *PaymentTestSuite) TestValidatePayment() {


### PR DESCRIPTION
Alteração para permitir Mock nas APIs

OBS : Houve alteração nas assinaturas (inclusão do httpClient) abaixo  : 
NewBoletos
NewBusiness
NewCustomers
NewPayment
NewBankStatement