### PR TITLE
Correção do processo de fund transfers

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -204,7 +204,7 @@ func FindTransferError(transferErrorResponse TransferErrorResponse) *grok.Error 
 			return v.grokError
 		}
 	}
-	return grok.NewError(http.StatusBadRequest, errorModel.Key+" - "+errorModel.Value)
+	return grok.NewError(http.StatusBadRequest, errorModel.Key + " - " + errorModel.Value)
 }
 
 func (e *Error) Error() string {

--- a/transfers.go
+++ b/transfers.go
@@ -139,23 +139,25 @@ func (t *Transfers) createTransferOperation(correlationID string, model Transfer
 
 	err = json.Unmarshal(respBody, &bodyErr)
 	if err != nil {
-		logrus.Error("error - createTransferOperation")
+		logrus.
+			WithError(err).
+			Error("error - createTransferOperation")
 		return nil, err
 	}
 
-	if len(bodyErr.Errors) > 0 {
-		logrus.Error("body error - createTransferOperation")
+	if bodyErr != nil && (len(bodyErr.Errors) > 0 || bodyErr.Code != "") {
+		logrus.
+			WithField("bankly_body_error", bodyErr).
+			Error("body error - createTransferOperation")
 		return nil, FindTransferError(*bodyErr)
 	}
 
 	logrus.
 		WithFields(logrus.Fields{
-			"response_status_code" : resp.StatusCode,
-			"response_body" : respBody,
+			"bankly_response_status_code" : resp.StatusCode,
 		}).
 		WithError(err).
 		Error("default error transfer - createTransferOperation")
-
 	return nil, ErrDefaultTransfers
 }
 
@@ -220,7 +222,7 @@ func (t *Transfers) FindTransfers(correlationID *string,
 		return nil, err
 	}
 
-	if len(bodyErr.Errors) > 0 {
+	if bodyErr != nil && (len(bodyErr.Errors) > 0 || bodyErr.Code != "") {
 		return nil, FindTransferError(*bodyErr)
 	}
 
@@ -292,7 +294,7 @@ func (t *Transfers) FindTransfersByCode(correlationID *string,
 		return nil, err
 	}
 
-	if len(bodyErr.Errors) > 0 {
+	if bodyErr != nil && (len(bodyErr.Errors) > 0 || bodyErr.Code != "") {
 		return nil, FindTransferError(*bodyErr)
 	}
 


### PR DESCRIPTION
- Correção do processo de mapeamento dos erros do Bankly, especificamente no fund transfer.
Estava mapeando apenas quando o array de erros era maior do que zero, mas o Bankly retorna em alguns casos o array de erros zerado e apenas o campo CODE informado.

Link Trello : 
https://trello.com/c/wupgnd30/286-bankly-sdk-corre%C3%A7%C3%A3o-mapeamento-do-cashoutlimitnotenough-na-fund-transfers