### PR TITLE
Feature/ticket 311 adjusts

### DIFF
--- a/card_test.go
+++ b/card_test.go
@@ -253,6 +253,7 @@ func (c *CardTestSuite) TestGetPCIByProxy_PASSWORD_INVALID_NOT_OK() {
 	card, err := c.card.GetPCIByProxy(c.ctx, &proxy, &cardPCIDTO)
 
 	c.assert.Error(err)
+	c.assert.Contains(err.Error(), "INVALID_CARD_PASSWORD")
 	c.assert.Nil(card)
 }
 

--- a/card_test.go
+++ b/card_test.go
@@ -205,7 +205,9 @@ func (c *CardTestSuite) TestActivateCardByProxy_OK() {
 
 	c.assert.NoError(activateErr)
 }
+*/
 
+/*
 func (c *CardTestSuite) TestUpdatePasswordByProxy_OK() {
 	card, err := c.card.GetCardsByIdentifier(c.ctx, "93707422046")
 
@@ -223,6 +225,7 @@ func (c *CardTestSuite) TestUpdatePasswordByProxy_OK() {
 	c.assert.NotNil(cardActivated)
 }
 */
+
 func (c *CardTestSuite) TestCreateCardPhysical_INVALID_PARAMETER_EMPTY() {
 	createCardModel := createCardModel("123456", "202142", bankly.PhysicalCardType)
 

--- a/errors.go
+++ b/errors.go
@@ -123,6 +123,12 @@ var (
 	ErrCardStatusUpdate = grok.NewError(http.StatusNotModified, "error update status card")
 	// ErrCardPasswordUpdate ...
 	ErrCardPasswordUpdate = grok.NewError(http.StatusNotModified, "error update password card")
+	// ErrInvalidPassword ...
+	ErrInvalidPassword = grok.NewError(http.StatusUnauthorized, "invalid password")
+	// ErrInvalidCardName ...
+	ErrInvalidCardName = grok.NewError(http.StatusBadRequest, "invalid card name")
+	// ErrInvalidIdentifier ...
+	ErrInvalidIdentifier = grok.NewError(http.StatusBadRequest, "invalid identifier")
 )
 
 // BanklyError ...
@@ -253,7 +259,7 @@ var transferErrorList = []TransferError{
 	},
 }
 
-// FindError ..
+// FindError Find errors.
 func FindError(code string, messages ...string) *Error {
 	code = verifyInvalidParameter(code, messages)
 
@@ -280,6 +286,7 @@ func FindErrorByErrorModel(response ErrorModel) *Error {
 	}
 }
 
+// verifyInvalidParameter Find the correspondent error message.
 func verifyInvalidParameter(code string, messages []string) string {
 	if code == "INVALID_PARAMETER" {
 		for _, m := range messages {
@@ -301,10 +308,34 @@ func verifyInvalidParameter(code string, messages []string) string {
 	return code
 }
 
-// Card
-func FindCardError(code string, messages ...string) *Error {
+var errorCardList = []Error{
+	{
+		ErrorKey:  "INVALID_CARD_PASSWORD",
+		GrokError: ErrInvalidPassword,
+	},
+	{
+		ErrorKey:  "INVALID_CARD_NAME_EMPTY",
+		GrokError: ErrInvalidCardName,
+	},
+	{
+		ErrorKey:  "INVALID_DOCUMENT_NUMBER_EMPTY",
+		GrokError: ErrInvalidIdentifier,
+	},
+	{
+		ErrorKey:  "INVALID_PARAMETER_CARD",
+		GrokError: ErrInvalidParameter,
+	},
+}
 
+// FindCardError Find cards errors.
+func FindCardError(code string, messages ...string) *Error {
 	code = verifyInvalidCardParameter(code, messages)
+
+	for _, v := range errorCardList {
+		if v.ErrorKey == code {
+			return &v
+		}
+	}
 
 	return &Error{
 		ErrorKey:  code,
@@ -312,14 +343,17 @@ func FindCardError(code string, messages ...string) *Error {
 	}
 }
 
+// verifyInvalidCardParameter Find the correspondent error message for Cards.
 func verifyInvalidCardParameter(code string, messages []string) string {
-	if code == "INVALID_PARAMETER" {
+	if code == "INVALID_PARAMETER" || code == "011" {
 		for _, m := range messages {
 			switch {
 			case strings.Contains(strings.ToLower(m), "card name"):
 				return "INVALID_CARD_NAME_EMPTY"
 			case strings.Contains(strings.ToLower(m), "document number"):
 				return "INVALID_DOCUMENT_NUMBER_EMPTY"
+			case strings.Contains(strings.ToLower(m), "invalid password"):
+				return "INVALID_CARD_PASSWORD"
 			default:
 				return "INVALID_PARAMETER_CARD"
 			}

--- a/errors.go
+++ b/errors.go
@@ -131,6 +131,9 @@ var (
 	ErrInvalidIdentifier = grok.NewError(http.StatusBadRequest, "invalid identifier")
 	// ErrCardAlreadyActivated ...
 	ErrCardAlreadyActivated = grok.NewError(http.StatusConflict, "card already activated")
+	// ErrOperationNotAllowedCardStatus ...
+	ErrOperationNotAllowedCardStatus = grok.NewError(http.StatusMethodNotAllowed, "operation not allowed for current card status")
+
 )
 
 // BanklyError ...
@@ -316,6 +319,10 @@ var errorCardList = []Error{
 		GrokError: ErrInvalidPassword,
 	},
 	{
+		ErrorKey:  "OPERATION_NOT_ALLOWED_FOR_CURRENT_CARD_STATUS",
+		GrokError: ErrOperationNotAllowedCardStatus,
+	},
+	{
 		ErrorKey:  "CARD_ALREADY_ACTIVATED",
 		GrokError: ErrCardAlreadyActivated,
 	},
@@ -362,6 +369,8 @@ func verifyInvalidCardParameter(code string, messages []string) string {
 				return "INVALID_PARAMETER_CARD"
 			}
 		}
+	} else if code == "009" {
+		return "OPERATION_NOT_ALLOWED_FOR_CURRENT_CARD_STATUS"
 	} else if code == "011" {
 		return "INVALID_CARD_PASSWORD"
 	} else if code == "021" {

--- a/errors.go
+++ b/errors.go
@@ -133,7 +133,6 @@ var (
 	ErrCardAlreadyActivated = grok.NewError(http.StatusConflict, "card already activated")
 	// ErrOperationNotAllowedCardStatus ...
 	ErrOperationNotAllowedCardStatus = grok.NewError(http.StatusMethodNotAllowed, "operation not allowed for current card status")
-
 )
 
 // BanklyError ...

--- a/errors.go
+++ b/errors.go
@@ -129,6 +129,8 @@ var (
 	ErrInvalidCardName = grok.NewError(http.StatusBadRequest, "invalid card name")
 	// ErrInvalidIdentifier ...
 	ErrInvalidIdentifier = grok.NewError(http.StatusBadRequest, "invalid identifier")
+	// ErrCardAlreadyActivated ...
+	ErrCardAlreadyActivated = grok.NewError(http.StatusConflict, "card already activated")
 )
 
 // BanklyError ...
@@ -314,6 +316,10 @@ var errorCardList = []Error{
 		GrokError: ErrInvalidPassword,
 	},
 	{
+		ErrorKey:  "CARD_ALREADY_ACTIVATED",
+		GrokError: ErrCardAlreadyActivated,
+	},
+	{
 		ErrorKey:  "INVALID_CARD_NAME_EMPTY",
 		GrokError: ErrInvalidCardName,
 	},
@@ -345,19 +351,21 @@ func FindCardError(code string, messages ...string) *Error {
 
 // verifyInvalidCardParameter Find the correspondent error message for Cards.
 func verifyInvalidCardParameter(code string, messages []string) string {
-	if code == "INVALID_PARAMETER" || code == "011" {
+	if code == "INVALID_PARAMETER" {
 		for _, m := range messages {
 			switch {
 			case strings.Contains(strings.ToLower(m), "card name"):
 				return "INVALID_CARD_NAME_EMPTY"
 			case strings.Contains(strings.ToLower(m), "document number"):
 				return "INVALID_DOCUMENT_NUMBER_EMPTY"
-			case strings.Contains(strings.ToLower(m), "invalid password"):
-				return "INVALID_CARD_PASSWORD"
 			default:
 				return "INVALID_PARAMETER_CARD"
 			}
 		}
+	} else if code == "011" {
+		return "INVALID_CARD_PASSWORD"
+	} else if code == "021" {
+		return "CARD_ALREADY_ACTIVATED"
 	}
 	return code
 }

--- a/model.go
+++ b/model.go
@@ -213,6 +213,12 @@ type ErrorResponse struct {
 	CodeMessageErrorResponse
 }
 
+// CardErrorResponse ...
+type CardErrorResponse struct {
+	ErrorKey string `json:"errorKey,omitempty"`
+	CodeMessageErrorResponse
+}
+
 // CodeMessageErrorResponse ...
 type CodeMessageErrorResponse struct {
 	Code    string `json:"code,omitempty"`
@@ -885,12 +891,12 @@ type FilterTicketsResponse struct {
 	Results []*GetTicketResponse `json:"results"`
 }
 
-// CardPasswordDTO
+// CardPasswordDTO ...
 type CardPCIDTO struct {
 	Password string `json:"password"`
 }
 
-//
+// CardPCIResponse ...
 type CardPCIResponse struct {
 	CardNumber     string `json:"cardNumber"`
 	Cvv            string `json:"cvv"`


### PR DESCRIPTION
- [CHECK-013] OBTER DADOS PCI DE UM CARTÃO - SENHA INVÁLIDA / ERRADA : Devemos alterar o HTTP Response Code para 401 Unauthorized.

- [CHECK-014] ATIVAÇÃO INICIAL DE UM CARTÃO RECEBIDO - CARTÃO JÁ ATIVADO ANTERIORMENTE : Devemos alterar para devolver HTTP Response Code 409 Conflict. 

- [CHECK-015] ATIVAÇÃO INICIAL DE UM CARTÃO RECEBIDO - ERROR RESPONSE - SENHA INVÁLIDA : Deve retornar HTTP Response Code 404 Unauthorized. 

- [CHECK-017] ATIVAÇÃO INICIAL DE UM CARTÃO RECEBIDO - ERROR RESPONSE - SENHA INVÁLIDA - DIFERENTE DE 4 DÍGITOS : Deve retornar 401